### PR TITLE
create login for manager and admin

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -12,6 +12,8 @@ import {
   VerifyOtpDto,
   VerifyOtpResponseDto,
 } from "src/auth/dtos/forgot-password.dto";
+import { ManagerResponseLoginDto } from "src/user/dtos/manager/auth-manager.dto";
+import { UserResponseLoginDto } from "src/user/dtos/user/user-response-login.dto";
 
 @Controller("auth")
 export class AuthController {
@@ -27,8 +29,16 @@ export class AuthController {
 
   @Public()
   @Post("login")
-  async login(@Body() dto: LoginDto): Promise<AuthCustomerResponseDto | AuthStylistResponseDto> {
+  async login(@Body() dto: LoginDto): Promise<AuthCustomerResponseDto | AuthStylistResponseDto | ManagerResponseLoginDto> {
     return this.authService.login(dto);
+  }
+
+  @Public()
+  @Post("login/admin") 
+  async loginAdmin(
+    @Body() dto: LoginDto,
+  ): Promise<{ access_token: string; admin: UserResponseLoginDto; }> {
+    return this.authService.loginAdmin(dto);
   }
 
   @Public()

--- a/backend/src/common/constants/error.constants.ts
+++ b/backend/src/common/constants/error.constants.ts
@@ -3,18 +3,22 @@ export const ERROR_MESSAGES = {
     EMAIL_NOT_FOUND: "Email is not registered",
     PASSWORD_INCORRECT: "Incorrect password",
     USER_INACTIVE: "User is inactive",
+    NOT_STYLIST_ROLE: "User is not a stylist",
+    NOT_MANAGER_ROLE: "User is not a manager",
+    NOT_ADMIN_ROLE: "User is not an admin",
+    UNSUPPORTED_ROLE: "Unsupported user role",
   },
   USER: {
     EMAIL_ALREADY_EXISTS: "Email already exists",
     PHONE_ALREADY_EXISTS: "Phone number already exists",
-    UN_AUTH: "Un"
+    UN_AUTH: "INVALID_CREDENTIALS"
   },
   SALON: {
   NOT_FOUND: "Salon not found",
   },
   ROLE:{
     NOT_FOUND: "ROLE NOT FOUND"
-  }
+  },
   OTP: {
     INVALID_OR_EXPIRED: "OTP is invalid or expired",
     EMAIL_SEND_FAILED: "Unable to send OTP email",

--- a/backend/src/common/enums/role-name.enum.ts
+++ b/backend/src/common/enums/role-name.enum.ts
@@ -1,0 +1,6 @@
+export enum RoleName {
+  CUSTOMER = 'CUSTOMER',
+  STYLIST = 'STYLIST',
+  MANAGER = 'MANAGER',
+  ADMIN = 'ADMIN',
+}

--- a/backend/src/user/dtos/manager/auth-manager.dto.ts
+++ b/backend/src/user/dtos/manager/auth-manager.dto.ts
@@ -1,0 +1,12 @@
+import { UserResponseLoginDto } from '../user/user-response-login.dto';
+
+export class ManagerResponseLoginDto extends UserResponseLoginDto {
+  salonId: string;
+  salonName: string;
+  salonAddress: string;
+}
+
+export class AuthManagerResponseDto {
+  access_token: string;
+  manager: ManagerResponseLoginDto;
+}

--- a/backend/src/user/dtos/manager/create-manager.dto.ts
+++ b/backend/src/user/dtos/manager/create-manager.dto.ts
@@ -1,0 +1,8 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+import { RegisterDto } from '../../../auth/dtos/register.dto';
+
+export class CreateManagerDto extends RegisterDto {
+  @IsNotEmpty()
+  @IsString()
+  salonId: string;
+}

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -4,12 +4,16 @@ import { CustomerService } from "./customer.service";
 import { CreateCustomerDto } from "./dtos/customer/create-customer.dto";
 import { CustomerResponseLoginDto } from "./dtos/customer/auth-customer.dto";
 import * as bcrypt from "bcrypt";
-import { buildCustomerLoginResponse, buildStylistLoginResponse } from "./utils/response-builder"; 
+import { buildCustomerLoginResponse, buildManagerLoginResponse, buildStylistLoginResponse, buildUserResponseForAdmin } from "./utils/response-builder"; 
 import { UnauthorizedException } from "@nestjs/common/exceptions/unauthorized.exception";
 import { ERROR_MESSAGES } from "../common/constants/error.constants";
 
 import { CreateStylistDto } from "./dtos/stylist/create-stylist.dto";
 import { StylistResponseLoginDto } from "./dtos/stylist/auth-stylist.dto";
+import { CreateManagerDto } from "./dtos/manager/create-manager.dto";
+import { ManagerResponseLoginDto } from "./dtos/manager/auth-manager.dto";
+import { RoleName } from "src/common/enums/role-name.enum";
+import { UserResponseLoginDto } from "./dtos/user/user-response-login.dto";
 
 @Injectable()
 export class UserService {
@@ -176,5 +180,50 @@ export class UserService {
     }
 
     return buildStylistLoginResponse(user, user.stylist);
+  }
+
+  public async createUserManager(dto: CreateManagerDto): Promise<ManagerResponseLoginDto> {
+    const { email, phone, password, salonId, ...rest } = dto;
+    if (await this.prisma.user.findUnique({ where: { email } })) { throw new BadRequestException(ERROR_MESSAGES.USER.EMAIL_ALREADY_EXISTS); }
+    if (phone && (await this.prisma.user.findUnique({ where: { phone } }))) { throw new BadRequestException(ERROR_MESSAGES.USER.PHONE_ALREADY_EXISTS); }
+    const salon = await this.prisma.salon.findUnique({ where: { id: salonId } });
+    if (!salon) { throw new BadRequestException(ERROR_MESSAGES.SALON.NOT_FOUND); }
+    const hashedPassword = await this.hashPassword(password);
+    const user = await this.prisma.user.create({
+      data: {
+        email, phone: phone ?? null, password: hashedPassword,
+        fullName: rest.fullName ?? "", gender: rest.gender ?? null, avatar: rest.avatar ?? null,
+        role: { connect: { name: RoleName.MANAGER } },
+        manager: { create: { salon: { connect: { id: salonId } } } },
+      },
+      include: { role: true, manager: { include: { salon: true } } },
+    });
+    return buildManagerLoginResponse(user, user.manager);
+  }
+
+  public async validateManager(email: string, password: string): Promise<ManagerResponseLoginDto> {
+    const user = await this.prisma.user.findUnique({
+      where: { email },
+      include: { role: true, manager: { include: { salon: true } } },
+    });
+    if (!user) { throw new UnauthorizedException(ERROR_MESSAGES.AUTH.EMAIL_NOT_FOUND); }
+    if (user.role.name !== RoleName.MANAGER) { throw new UnauthorizedException(ERROR_MESSAGES.AUTH.NOT_MANAGER_ROLE); }
+    if (!user.isActive) { throw new UnauthorizedException(ERROR_MESSAGES.AUTH.USER_INACTIVE); }
+    const passwordValid = await bcrypt.compare(password, user.password);
+    if (!passwordValid) { throw new UnauthorizedException(ERROR_MESSAGES.AUTH.PASSWORD_INCORRECT); }
+    return buildManagerLoginResponse(user, user.manager);
+  }
+
+    public async validateAdmin(email: string, password: string): Promise<UserResponseLoginDto> {
+    const user = await this.prisma.user.findUnique({
+      where: { email },
+      include: { role: true },
+    });
+    if (!user) { throw new UnauthorizedException(ERROR_MESSAGES.AUTH.EMAIL_NOT_FOUND); }
+    if (user.role.name !== RoleName.ADMIN) { throw new UnauthorizedException(ERROR_MESSAGES.AUTH.NOT_ADMIN_ROLE); }
+    if (!user.isActive) { throw new UnauthorizedException(ERROR_MESSAGES.AUTH.USER_INACTIVE); }
+    const passwordValid = await bcrypt.compare(password, user.password);
+    if (!passwordValid) { throw new UnauthorizedException(ERROR_MESSAGES.AUTH.PASSWORD_INCORRECT); }
+    return buildUserResponseForAdmin(user); 
   }
 }

--- a/backend/src/user/utils/response-builder.ts
+++ b/backend/src/user/utils/response-builder.ts
@@ -1,5 +1,7 @@
 import { CustomerResponseLoginDto } from "../dtos/customer/auth-customer.dto";
+import { ManagerResponseLoginDto } from "../dtos/manager/auth-manager.dto";
 import { StylistResponseLoginDto } from "../dtos/stylist/auth-stylist.dto";
+import { UserResponseLoginDto } from "../dtos/user/user-response-login.dto";
 
 interface RoleData {
   id: string;
@@ -109,5 +111,37 @@ export function buildStylistLoginResponse(
     salonId: stylist?.salonId ?? '', 
     salonName: stylist?.salon?.name ?? '', 
     salonAddress: stylist?.salon?.address ?? '',
+  };
+}
+
+interface ManagerData {
+  id: string; userId: string; salonId: string; createdAt: Date; updatedAt: Date;
+  salon: { id: string; name: string; address: string; };
+}
+export function buildManagerLoginResponse(user: UserData, manager?: ManagerData | null,): ManagerResponseLoginDto {
+  return {
+    id: user.id, fullName: user.fullName ?? "", email: user.email, phone: user.phone,
+    gender: user.gender ?? null, avatar: user.avatar ?? null, createdAt: user.createdAt,
+    updatedAt: user.updatedAt, isActive: user.isActive,
+    role: { name: user.role.name, description: user.role.description ?? undefined, },
+    salonId: manager?.salonId ?? '', salonName: manager?.salon?.name ?? '', salonAddress: manager?.salon?.address ?? '',
+  };
+}
+
+export function buildUserResponseForAdmin(user: UserData): UserResponseLoginDto {
+  return {
+    id: user.id,
+    fullName: user.fullName ?? "",
+    email: user.email,
+    phone: user.phone,
+    gender: user.gender ?? null,
+    avatar: user.avatar ?? null,
+    createdAt: user.createdAt,
+    updatedAt: user.updatedAt,
+    isActive: user.isActive,
+    role: {
+      name: user.role.name,
+      description: user.role.description ?? undefined,
+    },
   };
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "hn_22-naitei-nodejs-hairstyle_booking",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
## Tính năng mới
- Đăng nhập Manager, Admin

## Thay đổi đã thực hiện
- Cập nhật `AuthController`, `AuthService`, `UserService`
- Thêm DTOs (`CreateManagerDto`, `ManagerResponseDto`)
- Chuyển đổi logic login thành một endpoint chung cho các vai trò.
- Tuy  nhiên admin phải dùng endpoint riêng và không tạo bảng trong CSDL chỉ tạo bản ghi