### PR TITLE
feat: Implement stylist favorite management

### DIFF
--- a/backend/src/common/constants/error.constants.ts
+++ b/backend/src/common/constants/error.constants.ts
@@ -6,6 +6,7 @@ export const ERROR_MESSAGES = {
     NOT_STYLIST_ROLE: "User is not a stylist",
     NOT_MANAGER_ROLE: "User is not a manager",
     NOT_ADMIN_ROLE: "User is not an admin",
+    NOT_CUSTOMER_ROLE: "User is not a customer",
     UNSUPPORTED_ROLE: "Unsupported user role",
     USER_NOT_FOUND: "User not found",
     STYLIST_NOT_FOUND: "Stylist not found",
@@ -46,5 +47,10 @@ export const ERROR_MESSAGES = {
   },
   CUSTOMER: {
     NOT_FOUND: "Customer not found",
+  },
+    FAVORITE: {
+    STYLIST_NOT_FOUND: "Stylist not found.",
+    ALREADY_FAVORITED: "Stylist is already in your favorites.",
+    NOT_FAVORITED: "Stylist is not in your favorites.",
   },
 };

--- a/backend/src/favourite/favorite.controller.ts
+++ b/backend/src/favourite/favorite.controller.ts
@@ -1,0 +1,36 @@
+import { Controller, Post, Delete, Param, UseGuards, Req, Get } from '@nestjs/common';
+import { FavoriteService } from './favorite.service';
+import { JwtAuthGuard } from "../common/guards/jwt-auth.guard";
+import { RolesGuard } from '../common/guards/roles.guard';
+import { Roles } from 'src/common/decorators/roles.decorator';
+import { RoleName } from 'src/common/enums/role-name.enum';
+import { CurrentUser } from 'src/common/decorators/current-user.decorator';
+import { JwtPayload } from 'src/common/types/jwt-payload.interface';
+
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles(RoleName.CUSTOMER)
+@Controller('favorites')
+export class FavoriteController {
+  constructor(private readonly favoriteService: FavoriteService) {}
+
+  @Post(':stylistId')
+  async addFavoriteStylist(
+    @CurrentUser() user: JwtPayload,
+    @Param('stylistId') stylistId: string,
+  ): Promise<any> {
+    return this.favoriteService.addFavoriteStylist(user.id, stylistId);
+  }
+
+  @Delete(':stylistId')
+  async removeFavoriteStylist(
+    @CurrentUser() user: JwtPayload,
+    @Param('stylistId') stylistId: string,
+  ): Promise<{ message: string }> {
+    return this.favoriteService.removeFavoriteStylist(user.id, stylistId);
+  }
+
+  @Get()
+  async getFavoriteStylists(@CurrentUser() user: JwtPayload): Promise<any[]> {
+    return this.favoriteService.getFavoriteStylists(user.id);
+  }
+}

--- a/backend/src/favourite/favorite.module.ts
+++ b/backend/src/favourite/favorite.module.ts
@@ -1,0 +1,18 @@
+import { Module } from '@nestjs/common';
+import { FavoriteController } from './favorite.controller';
+import { FavoriteService } from './favorite.service';
+import { PrismaService } from 'src/prisma/prisma.service';
+
+import { AuthModule } from 'src/auth/auth.module';
+
+@Module({
+  imports: [
+    AuthModule,
+  ],
+  controllers: [FavoriteController],
+  providers: [
+    FavoriteService,
+    PrismaService,
+  ],
+})
+export class FavoriteModule {}

--- a/backend/src/favourite/favorite.service.ts
+++ b/backend/src/favourite/favorite.service.ts
@@ -1,0 +1,113 @@
+import { Injectable, BadRequestException, NotFoundException, ConflictException, ForbiddenException } from '@nestjs/common';
+import { PrismaService } from 'src/prisma/prisma.service';
+import { ERROR_MESSAGES } from 'src/common/constants/error.constants';
+import { RoleName } from 'src/common/enums/role-name.enum';
+
+@Injectable()
+export class FavoriteService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async addFavoriteStylist(customerUserId: string, stylistId: string): Promise<any> {
+    const customer = await this.prisma.customer.findUnique({
+      where: { userId: customerUserId },
+      select: { id: true, user: { select: { role: true } } }
+    });
+    if (!customer || customer.user.role.name !== RoleName.CUSTOMER) {
+      throw new ForbiddenException(ERROR_MESSAGES.AUTH.NOT_CUSTOMER_ROLE);
+    }
+
+    const stylist = await this.prisma.stylist.findUnique({
+      where: { id: stylistId },
+      select: { id: true, user: { select: { role: true } } }
+    });
+    if (!stylist || stylist.user.role.name !== RoleName.STYLIST) {
+      throw new NotFoundException(ERROR_MESSAGES.FAVORITE.STYLIST_NOT_FOUND);
+    }
+
+    const existingFavorite = await this.prisma.stylistFavorite.findFirst({
+      where: {
+        customerId: customer.id,
+        stylistId: stylist.id,
+      },
+    });
+    if (existingFavorite) {
+      throw new ConflictException(ERROR_MESSAGES.FAVORITE.ALREADY_FAVORITED);
+    }
+
+    return this.prisma.stylistFavorite.create({
+      data: {
+        customerId: customer.id,
+        stylistId: stylist.id,
+      },
+      include: {
+        stylist: { include: { user: true } },
+        customer: { include: { user: true } },
+      },
+    });
+  }
+
+  async removeFavoriteStylist(customerUserId: string, stylistId: string): Promise<{ message: string }> {
+    const customer = await this.prisma.customer.findUnique({
+      where: { userId: customerUserId },
+      select: { id: true, user: { select: { role: true } } }
+    });
+    if (!customer || customer.user.role.name !== RoleName.CUSTOMER) {
+      throw new ForbiddenException(ERROR_MESSAGES.AUTH.NOT_CUSTOMER_ROLE);
+    }
+
+    const stylist = await this.prisma.stylist.findUnique({
+      where: { id: stylistId },
+      select: { id: true }
+    });
+    if (!stylist) {
+      throw new NotFoundException(ERROR_MESSAGES.FAVORITE.STYLIST_NOT_FOUND);
+    }
+
+    const deleteResult = await this.prisma.stylistFavorite.deleteMany({
+      where: {
+        customerId: customer.id,
+        stylistId: stylist.id,
+      },
+    });
+
+    if (deleteResult.count === 0) {
+      throw new NotFoundException(ERROR_MESSAGES.FAVORITE.NOT_FAVORITED);
+    }
+
+    return { message: 'Stylist removed from favorites successfully.' };
+  }
+
+  async getFavoriteStylists(customerUserId: string): Promise<any[]> {
+    const customer = await this.prisma.customer.findUnique({
+      where: { userId: customerUserId },
+      select: { id: true, user: { select: { role: true } } }
+    });
+    if (!customer || customer.user.role.name !== RoleName.CUSTOMER) {
+      throw new ForbiddenException(ERROR_MESSAGES.AUTH.NOT_CUSTOMER_ROLE);
+    }
+
+    const favorites = await this.prisma.stylistFavorite.findMany({
+      where: { customerId: customer.id },
+      include: {
+        stylist: {
+          include: {
+            user: true,
+            salon: true
+          }
+        }
+      }
+    });
+
+    return favorites.map(fav => ({
+      id: fav.stylist.id,
+      fullName: fav.stylist.user.fullName,
+      email: fav.stylist.user.email,
+      phone: fav.stylist.user.phone,
+      avatar: fav.stylist.user.avatar,
+      rating: fav.stylist.rating,
+      ratingCount: fav.stylist.ratingCount,
+      salonName: fav.stylist.salon.name,
+      salonAddress: fav.stylist.salon.address,
+    }));
+  }
+}


### PR DESCRIPTION
## Tính năng mới được triển khai:

PR này giới thiệu module quản lý danh sách Stylist yêu thích, cho phép khách hàng tương tác với các stylist mà họ yêu thích.

### Các API chính:

1.  **Thêm Stylist vào danh sách yêu thích:**
    *   **Endpoint:** `POST /favorites/:stylistId`
    *   **Mô tả:** Cho phép khách hàng thêm một stylist cụ thể vào danh sách yêu thích của mình.
    *   **Quyền truy cập:** Chỉ khách hàng (`CUSTOMER`).
    *   **Lưu ý:**
        *   Kiểm tra tính hợp lệ của `stylistId`.
        *   Ngăn chặn việc yêu thích trùng lặp (khách hàng không thể yêu thích cùng một stylist nhiều lần).
        *   Trả về lỗi nếu stylist không tồn tại hoặc đã được yêu thích.

2.  **Bỏ Stylist khỏi danh sách yêu thích:**
    *   **Endpoint:** `DELETE /favorites/:stylistId`
    *   **Mô tả:** Cho phép khách hàng bỏ một stylist khỏi danh sách yêu thích của mình.
    *   **Quyền truy cập:** Chỉ khách hàng (`CUSTOMER`).
    *   **Lưu ý:**
        *   Trả về lỗi nếu stylist không có trong danh sách yêu thích của khách hàng đó.

3.  **Lấy danh sách Stylist yêu thích:**
    *   **Endpoint:** `GET /favorites`
    *   **Mô tả:** Trả về danh sách tất cả các stylist mà khách hàng hiện tại đã yêu thích.
    *   **Quyền truy cập:** Chỉ khách hàng (`CUSTOMER`).
