### PR TITLE
feat(stylist): add leave request, notifications, and work schedule display for Stylist

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -15,10 +15,14 @@ import ServiceManagementPage from "./pages/admin/ServiceManagementPage";
 import ManagerDashboardPage from "./pages/manager/ManagerDashboardPage";
 import ManagerStylistManagementPage from "./pages/manager/ManagerStylistManagementPage";
 import ManagerDayOffManagementPage from "./pages/manager/ManagerDayOffManagementPage";
-import Stylists from "./pages/Stylists"
+import Stylists from "./pages/Stylists";
 import BookingFormPage from "./pages/BookingFormPage";
 import BookingListPage from "./pages/BookingListPage";
 import BookingDetailPage from "./pages/BookingDetailPage";
+import StylistNotificationsPage from "./pages/stylist/StylistNotificationsPage";
+import StylistLeaveManagementPage from "./pages/stylist/StylistLeaveManagementPage";
+import StylistCreateLeavePage from "./pages/stylist/StylistCreateLeavePage";
+import StylistDashboardPage from "./pages/stylist/StylistDashboardPage";
 
 function App() {
   return (
@@ -45,6 +49,13 @@ function App() {
           <Route path="/manager/dashboard" element={<ManagerDashboardPage />} />
           <Route path="/manager/stylists" element={<ManagerStylistManagementPage />} />
           <Route path="/manager/dayoff" element={<ManagerDayOffManagementPage />} />
+          
+          {/* Stylist */}
+          <Route path="/stylist-dashboard" element={<StylistDashboardPage />} />
+          <Route path="/stylist-dashboard/notifications" element={<StylistNotificationsPage />} />
+          <Route path="/stylist-dashboard/notifications/*"element={<StylistNotificationsPage />} />
+          <Route path="/stylist-dashboard/leaves" element={<StylistLeaveManagementPage />} />
+          <Route path="/stylist-dashboard/leaves/create" element={<StylistCreateLeavePage />} />
         </Routes>
       </AuthProvider>
     </BrowserRouter>

--- a/frontend/src/api/services/notificationApi.js
+++ b/frontend/src/api/services/notificationApi.js
@@ -1,0 +1,10 @@
+import axiosClient from "../axiosClient";
+
+export const notificationApi = {
+  getAllForStylist: () =>
+    axiosClient.get("/notifications"),
+
+  markAsRead: (id) => axiosClient.patch(`/notifications/${id}/read`),
+
+  getById: (id) => axiosClient.get(`/notifications/${id}`),
+};

--- a/frontend/src/components/stylistDashboard/CreateLeaves.jsx
+++ b/frontend/src/components/stylistDashboard/CreateLeaves.jsx
@@ -1,0 +1,151 @@
+import React, { useState } from "react";
+import axiosClient from "../../api/axiosClient";
+
+export default function CreateLeave() {
+  const [date, setDate] = useState("");
+  const [reason, setReason] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [showSuccess, setShowSuccess] = useState(false);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!date) return alert("Vui lòng chọn ngày nghỉ");
+
+    try {
+      setLoading(true);
+      await axiosClient.post("/leaves", {
+        date,
+        reason: reason.trim() || undefined,
+      });
+
+      setShowSuccess(true);
+      setTimeout(() => setShowSuccess(false), 2000);
+
+      setDate("");
+      setReason("");
+    } catch (err) {
+      console.error("Không thể gửi yêu cầu nghỉ phép:", err);
+      alert("Không thể tạo yêu cầu nghỉ. Vui lòng thử lại.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-indigo-50 p-4">
+      <div className="max-w-2xl mx-auto">
+        {/* Success Notification */}
+        {showSuccess && (
+          <div className="fixed top-6 right-6 z-50 animate-in slide-in-from-top-2 duration-300">
+            <div className="bg-gradient-to-r from-green-500 to-emerald-500 text-white px-6 py-3 rounded-2xl shadow-2xl flex items-center space-x-3 backdrop-blur-sm">
+              <div className="w-6 h-6 bg-white/20 rounded-full flex items-center justify-center">
+                <span className="text-sm">✓</span>
+              </div>
+              <span className="font-medium">Gửi yêu cầu nghỉ phép thành công!</span>
+            </div>
+          </div>
+        )}
+
+        {/* Header */}
+        <div className="text-center mb-8">
+          <div className="w-16 h-16 bg-gradient-to-br from-blue-500 to-indigo-600 rounded-2xl mx-auto mb-4 flex items-center justify-center shadow-lg">
+            <svg className="w-8 h-8 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+            </svg>
+          </div>
+          <h1 className="text-3xl font-bold bg-gradient-to-r from-gray-800 to-gray-600 bg-clip-text text-transparent">
+            Tạo yêu cầu nghỉ phép
+          </h1>
+          <p className="text-gray-500 mt-2">Điền thông tin để gửi yêu cầu nghỉ phép của bạn</p>
+        </div>
+
+        {/* Form Card */}
+        <div className="bg-white/70 backdrop-blur-sm rounded-3xl shadow-xl border border-white/20 overflow-hidden">
+          <div className="p-8">
+            <form onSubmit={handleSubmit} className="space-y-6">
+              {/* Date Input */}
+              <div className="space-y-2">
+                <label className="block">
+                  <div className="flex items-center space-x-2 mb-3">
+                    <div className="w-5 h-5 bg-blue-100 rounded-lg flex items-center justify-center">
+                      <svg className="w-3 h-3 text-blue-600" fill="currentColor" viewBox="0 0 20 20">
+                        <path fillRule="evenodd" d="M6 2a1 1 0 00-1 1v1H4a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V6a2 2 0 00-2-2h-1V3a1 1 0 10-2 0v1H7V3a1 1 0 00-1-1zm0 5a1 1 0 000 2h8a1 1 0 100-2H6z" clipRule="evenodd" />
+                      </svg>
+                    </div>
+                    <span className="text-sm font-semibold text-gray-700">Ngày nghỉ phép</span>
+                    <span className="text-red-500 text-sm">*</span>
+                  </div>
+                  <input
+                    type="date"
+                    className="w-full px-4 py-3 bg-gray-50/50 border-2 border-gray-200 rounded-2xl focus:border-blue-500 focus:bg-white focus:outline-none transition-all duration-200 text-gray-800"
+                    value={date}
+                    onChange={(e) => setDate(e.target.value)}
+                    required
+                  />
+                </label>
+              </div>
+
+              {/* Reason Input */}
+              <div className="space-y-2">
+                <label className="block">
+                  <div className="flex items-center space-x-2 mb-3">
+                    <div className="w-5 h-5 bg-amber-100 rounded-lg flex items-center justify-center">
+                      <svg className="w-3 h-3 text-amber-600" fill="currentColor" viewBox="0 0 20 20">
+                        <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-8-3a1 1 0 00-.867.5 1 1 0 11-1.731-1A3 3 0 0113 8a3.001 3.001 0 01-2 2.83V11a1 1 0 11-2 0v-1a1 1 0 011-1 1 1 0 100-2zm0 8a1 1 0 100-2 1 1 0 000 2z" clipRule="evenodd" />
+                      </svg>
+                    </div>
+                    <span className="text-sm font-semibold text-gray-700">Lý do nghỉ phép</span>
+                    <span className="text-xs bg-gray-100 text-gray-600 px-2 py-1 rounded-full">Tùy chọn</span>
+                  </div>
+                  <textarea
+                    className="w-full px-4 py-3 bg-gray-50/50 border-2 border-gray-200 rounded-2xl focus:border-blue-500 focus:bg-white focus:outline-none transition-all duration-200 text-gray-800 resize-none"
+                    rows={4}
+                    value={reason}
+                    onChange={(e) => setReason(e.target.value)}
+                    placeholder="Ví dụ: khám bệnh, việc cá nhân, du lịch..."
+                  />
+                </label>
+              </div>
+
+              {/* Submit Button */}
+              <div className="pt-4">
+                <button
+                  type="submit"
+                  disabled={loading}
+                  className="w-full group relative overflow-hidden bg-gradient-to-r from-blue-600 to-indigo-600 text-white font-semibold py-4 px-6 rounded-2xl shadow-lg hover:shadow-xl disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-300 transform hover:scale-[1.02] disabled:hover:scale-100"
+                >
+                  <div className="absolute inset-0 bg-gradient-to-r from-blue-700 to-indigo-700 opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
+                  <div className="relative flex items-center justify-center space-x-2">
+                    {loading ? (
+                      <>
+                        <div className="w-5 h-5 border-2 border-white/30 border-t-white rounded-full animate-spin"></div>
+                        <span>Đang gửi yêu cầu...</span>
+                      </>
+                    ) : (
+                      <>
+                        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8" />
+                        </svg>
+                        <span>Gửi yêu cầu nghỉ phép</span>
+                      </>
+                    )}
+                  </div>
+                </button>
+              </div>
+            </form>
+          </div>
+
+          {/* Bottom Decoration */}
+          <div className="h-2 bg-gradient-to-r from-blue-500 via-indigo-500 to-purple-500"></div>
+        </div>
+
+        {/* Footer Note */}
+        <div className="text-center mt-8">
+          <p className="text-sm text-gray-500">
+            Yêu cầu sẽ được gửi đến quản lý để phê duyệt
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/stylistDashboard/Leaves.jsx
+++ b/frontend/src/components/stylistDashboard/Leaves.jsx
@@ -1,0 +1,338 @@
+import React, { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import axiosClient from "../../api/axiosClient";
+
+export default function Leaves() {
+  const [leaves, setLeaves] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [cancellingId, setCancellingId] = useState(null);
+
+  useEffect(() => {
+    fetchLeaves();
+  }, []);
+
+  const pickArray = (res) => {
+    const candidates = [
+      res,
+      res?.data,
+      res?.data?.data,
+      res?.data?.items,
+      res?.result,
+      res?.payload,
+    ];
+    for (const c of candidates) {
+      if (Array.isArray(c)) return c;
+    }
+    if (Array.isArray(res?.data?.result)) return res.data.result;
+    return [];
+  };
+
+  const fetchLeaves = async () => {
+    try {
+      setLoading(true);
+      const res = await axiosClient.get("/leaves");
+      const arr = pickArray(res);
+      setLeaves(arr.map(normalizeLeave));
+    } catch (error) {
+      console.error("Error fetching leaves:", error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const normalizeLeave = (x) => {
+    return {
+      id: x.id ?? x._id ?? x.leaveId,
+      date: x.date ?? x.leaveDate ?? x.day,
+      reason: x.reason ?? x.note ?? "",
+      status: x.status ?? x.state ?? "PENDING",
+    };
+  };
+
+  const handleCancel = async (id) => {
+    if (!window.confirm("Bạn có chắc muốn hủy đơn nghỉ này?")) return;
+    try {
+      setCancellingId(id);
+      await axiosClient.delete(`/leaves/${id}`);
+      setLeaves((prev) =>
+        prev.map((x) => (x.id === id ? { ...x, status: "CANCELLED" } : x))
+      );
+    } catch (error) {
+      console.error("Lỗi khi hủy đơn:", error);
+      alert("Không thể hủy đơn nghỉ.");
+    } finally {
+      setCancellingId(null);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-blue-50 p-6">
+      <div className="max-w-7xl mx-auto">
+        {/* Header Section */}
+        <div className="mb-8">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center space-x-4">
+              <div className="w-12 h-12 bg-gradient-to-br from-blue-500 to-indigo-600 rounded-xl flex items-center justify-center shadow-lg">
+                <svg className="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v10a2 2 0 002 2h8a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
+                </svg>
+              </div>
+              <div>
+                <h1 className="text-3xl font-bold bg-gradient-to-r from-gray-800 to-gray-600 bg-clip-text text-transparent">
+                  Nghỉ phép
+                </h1>
+                <p className="text-gray-500 mt-1">Quản lý các yêu cầu nghỉ phép của bạn</p>
+              </div>
+            </div>
+            
+            <Link
+              to="create"
+              className="group flex items-center space-x-2 bg-gradient-to-r from-blue-600 to-indigo-600 text-white px-6 py-3 rounded-xl shadow-lg hover:shadow-xl transition-all duration-300 transform hover:scale-105"
+            >
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
+              </svg>
+              <span className="font-medium">Tạo yêu cầu</span>
+            </Link>
+          </div>
+        </div>
+
+        {/* Stats Summary */}
+        {!loading && leaves.length > 0 && (
+          <div className="mb-8 grid grid-cols-1 md:grid-cols-4 gap-4">
+            {[
+              { status: 'PENDING', label: 'Chờ duyệt', color: 'yellow' },
+              { status: 'APPROVED', label: 'Đã duyệt', color: 'green' },
+              { status: 'REJECTED', label: 'Từ chối', color: 'red' },
+              { status: 'CANCELLED', label: 'Đã hủy', color: 'gray' }
+            ].map(({ status, label, color }) => {
+              const count = leaves.filter(l => l.status === status).length;
+              return (
+                <div key={status} className="bg-white/60 backdrop-blur-sm rounded-2xl p-4 border border-white/20">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <p className="text-sm text-gray-600">{label}</p>
+                      <p className="text-2xl font-bold text-gray-900">{count}</p>
+                    </div>
+                    <div className={`w-3 h-3 rounded-full ${statusDot(status)}`}></div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+
+        {/* Main Content Card */}
+        <div className="bg-white/70 backdrop-blur-sm rounded-3xl shadow-xl border border-white/20 overflow-hidden">
+          {/* Table Container */}
+          <div className="overflow-x-auto">
+            <table className="w-full">
+              <thead>
+                <tr className="bg-gradient-to-r from-gray-50 to-gray-100/80">
+                  <Th>
+                    <div className="flex items-center space-x-2">
+                      <svg className="w-4 h-4 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                      </svg>
+                      <span>Ngày</span>
+                    </div>
+                  </Th>
+                  <Th>
+                    <div className="flex items-center space-x-2">
+                      <svg className="w-4 h-4 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                      </svg>
+                      <span>Lý do</span>
+                    </div>
+                  </Th>
+                  <Th>
+                    <div className="flex items-center space-x-2">
+                      <svg className="w-4 h-4 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+                      </svg>
+                      <span>Trạng thái</span>
+                    </div>
+                  </Th>
+                  <Th className="text-right">
+                    <div className="flex items-center justify-end space-x-2">
+                      <svg className="w-4 h-4 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 5v.01M12 12v.01M12 19v.01M12 6a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2z" />
+                      </svg>
+                      <span>Thao tác</span>
+                    </div>
+                  </Th>
+                </tr>
+              </thead>
+              <tbody>
+                {loading ? (
+                  <tr>
+                    <Td colSpan={4}>
+                      <div className="flex items-center justify-center py-12">
+                        <div className="flex items-center space-x-3">
+                          <div className="w-6 h-6 border-2 border-blue-200 border-t-blue-600 rounded-full animate-spin"></div>
+                          <span className="text-gray-600 font-medium">Đang tải dữ liệu...</span>
+                        </div>
+                      </div>
+                    </Td>
+                  </tr>
+                ) : leaves.length === 0 ? (
+                  <tr>
+                    <Td colSpan={4}>
+                      <div className="flex flex-col items-center justify-center py-16">
+                        <div className="w-20 h-20 bg-gray-100 rounded-full flex items-center justify-center mb-4">
+                          <svg className="w-10 h-10 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v10a2 2 0 002 2h8a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
+                          </svg>
+                        </div>
+                        <h3 className="text-lg font-semibold text-gray-600 mb-2">Chưa có đơn nghỉ nào</h3>
+                        <p className="text-gray-500 mb-6">Bạn chưa tạo yêu cầu nghỉ phép nào</p>
+                        <Link
+                          to="create"
+                          className="bg-gradient-to-r from-blue-500 to-indigo-500 text-white px-6 py-3 rounded-xl hover:shadow-lg transition-all duration-300"
+                        >
+                          Tạo yêu cầu đầu tiên
+                        </Link>
+                      </div>
+                    </Td>
+                  </tr>
+                ) : (
+                  leaves.map((x, index) => (
+                    <tr
+                      key={x.id}
+                      className={`border-t border-gray-100 hover:bg-blue-50/50 transition-colors duration-200 ${
+                        index % 2 === 0 ? 'bg-white/50' : 'bg-gray-50/30'
+                      }`}
+                    >
+                      <Td>
+                        <div className="flex items-center space-x-3">
+                          <div className="w-8 h-8 bg-blue-100 rounded-lg flex items-center justify-center">
+                            <span className="text-xs font-semibold text-blue-600">
+                              {formatVN(x.date).split('/')[0]}
+                            </span>
+                          </div>
+                          <div>
+                            <div className="font-medium text-gray-900">{formatVN(x.date)}</div>
+                          </div>
+                        </div>
+                      </Td>
+                      <Td>
+                        <div className="max-w-xs">
+                          {x.reason ? (
+                            <span className="text-gray-700">{x.reason}</span>
+                          ) : (
+                            <span className="text-gray-400 italic">Không có lý do</span>
+                          )}
+                        </div>
+                      </Td>
+                      <Td>
+                        <span
+                          className={`inline-flex items-center px-3 py-1.5 rounded-full text-xs font-semibold ${statusStyle(x.status)}`}
+                        >
+                          <span className={`w-2 h-2 rounded-full mr-2 ${statusDot(x.status)}`}></span>
+                          {labelStatus(x.status)}
+                        </span>
+                      </Td>
+                      <Td className="text-right">
+                        {x.status === "PENDING" ? (
+                          <button
+                            onClick={() => handleCancel(x.id)}
+                            disabled={cancellingId === x.id}
+                            className="group inline-flex items-center space-x-2 px-4 py-2 border border-red-200 text-red-600 rounded-xl hover:bg-red-50 hover:border-red-300 disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-200"
+                          >
+                            {cancellingId === x.id ? (
+                              <>
+                                <div className="w-4 h-4 border-2 border-red-300 border-t-red-600 rounded-full animate-spin"></div>
+                                <span className="text-sm font-medium">Đang hủy...</span>
+                              </>
+                            ) : (
+                              <>
+                                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                                </svg>
+                                <span className="text-sm font-medium">Hủy</span>
+                              </>
+                            )}
+                          </button>
+                        ) : (
+                          <span className="text-gray-300">—</span>
+                        )}
+                      </Td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+
+          {/* Bottom Decoration */}
+          <div className="h-1 bg-gradient-to-r from-blue-500 via-indigo-500 to-purple-500"></div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const Th = (p) => (
+  <th
+    {...p}
+    className={
+      "px-6 py-4 text-left font-semibold text-gray-700 text-sm " + (p.className || "")
+    }
+  />
+);
+const Td = (p) => <td {...p} className={"px-6 py-4 " + (p.className || "")} />;
+
+function formatVN(iso) {
+  if (!iso) return "—";
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return String(iso);
+  const dd = String(d.getDate()).padStart(2, "0");
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  const yyyy = d.getFullYear();
+  return `${dd}/${mm}/${yyyy}`;
+}
+
+function labelStatus(status) {
+  switch (status) {
+    case "PENDING":
+      return "Chờ duyệt";
+    case "APPROVED":
+      return "Đã duyệt";
+    case "REJECTED":
+      return "Từ chối";
+    case "CANCELLED":
+      return "Đã hủy";
+    default:
+      return status;
+  }
+}
+
+function statusStyle(status) {
+  switch (status) {
+    case "PENDING":
+      return "bg-yellow-50 text-yellow-700 border border-yellow-200";
+    case "APPROVED":
+      return "bg-green-50 text-green-700 border border-green-200";
+    case "REJECTED":
+      return "bg-red-50 text-red-700 border border-red-200";
+    case "CANCELLED":
+      return "bg-gray-50 text-gray-600 border border-gray-200";
+    default:
+      return "bg-gray-50 text-gray-600 border border-gray-200";
+  }
+}
+
+function statusDot(status) {
+  switch (status) {
+    case "PENDING":
+      return "bg-yellow-400";
+    case "APPROVED":
+      return "bg-green-400";
+    case "REJECTED":
+      return "bg-red-400";
+    case "CANCELLED":
+      return "bg-gray-400";
+    default:
+      return "bg-gray-400";
+  }
+}

--- a/frontend/src/components/stylistDashboard/NotificationDetail.jsx
+++ b/frontend/src/components/stylistDashboard/NotificationDetail.jsx
@@ -1,0 +1,191 @@
+import React, { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { notificationApi } from "../../api/services/notificationApi";
+
+export default function NotificationDetail() {
+  const [data, setData] = useState(null);
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(true);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const id = sessionStorage.getItem("selectedNotificationId");
+    if (!id) {
+      setError("Không tìm thấy thông báo");
+      setLoading(false);
+      return;
+    }
+
+    fetchDetail(id);
+  }, []);
+
+  const fetchDetail = async (id) => {
+    try {
+      const res = await notificationApi.getById(id);
+      const payload = res?.data ?? res;
+      setData(payload);
+    } catch (e) {
+      console.error("Không thể tải chi tiết thông báo:", e);
+      setError("Không thể tải chi tiết thông báo");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-indigo-50 flex items-center justify-center">
+        <div className="flex items-center space-x-3">
+          <div className="w-8 h-8 border-3 border-indigo-200 border-t-indigo-600 rounded-full animate-spin"></div>
+          <span className="text-gray-600 font-medium text-lg">Đang tải chi tiết thông báo...</span>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-red-50 flex items-center justify-center">
+        <div className="text-center">
+          <div className="w-20 h-20 bg-red-100 rounded-full flex items-center justify-center mb-4 mx-auto">
+            <svg className="w-10 h-10 text-red-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+          </div>
+          <h3 className="text-xl font-semibold text-red-600 mb-2">Lỗi tải dữ liệu</h3>
+          <p className="text-gray-600 mb-6">{error}</p>
+          <button
+            onClick={() => navigate(-1)}
+            className="inline-flex items-center space-x-2 px-6 py-3 bg-gradient-to-r from-red-500 to-red-600 text-white rounded-xl hover:shadow-lg transition-all duration-300"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+            </svg>
+            <span>Quay lại</span>
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-indigo-50 py-8">
+      <div className="max-w-4xl mx-auto px-6">
+        {/* Header Section */}
+        <div className="mb-8">
+          <button
+            onClick={() => navigate(-1)}
+            className="group inline-flex items-center space-x-2 text-gray-600 hover:text-indigo-600 transition-colors duration-200 mb-6"
+          >
+            <svg className="w-5 h-5 group-hover:transform group-hover:-translate-x-1 transition-transform duration-200" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+            </svg>
+            <span className="font-medium">Quay lại danh sách</span>
+          </button>
+
+          <div className="flex items-center space-x-4">
+            <div className="w-12 h-12 bg-gradient-to-br from-indigo-500 to-purple-600 rounded-xl flex items-center justify-center shadow-lg">
+              <svg className="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 17h5l-5 5v-5zM4 2h13a2 2 0 012 2v4l-7 7H4a2 2 0 01-2-2V4a2 2 0 012-2z" />
+              </svg>
+            </div>
+            <div>
+              <h1 className="text-3xl font-bold bg-gradient-to-r from-gray-800 to-gray-600 bg-clip-text text-transparent">
+                Chi tiết thông báo
+              </h1>
+              <p className="text-gray-500 mt-1">Xem nội dung chi tiết thông báo</p>
+            </div>
+          </div>
+        </div>
+
+        {/* Main Content Card */}
+        <div className="bg-white/80 backdrop-blur-sm rounded-3xl shadow-2xl border border-white/20 overflow-hidden">
+          {/* Header with gradient background */}
+          <div className="bg-gradient-to-r from-indigo-500 via-purple-500 to-pink-500 p-6">
+            <div className="flex items-start space-x-4">
+              <div className="w-16 h-16 bg-white/20 backdrop-blur-sm rounded-2xl flex items-center justify-center">
+                <svg className="w-8 h-8 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 17h5l-5 5v-5zM4 2h13a2 2 0 012 2v4l-7 7H4a2 2 0 01-2-2V4a2 2 0 012-2z" />
+                </svg>
+              </div>
+              <div className="flex-1">
+                <h2 className="text-2xl font-bold text-white mb-3 leading-tight">
+                  {data.title}
+                </h2>
+                <div className="flex items-center space-x-2 text-white/90">
+                  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+                  </svg>
+                  <span className="font-medium">
+                    {new Date(data.createdAt).toLocaleString()}
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* Content Section */}
+          <div className="p-8">
+            <div className="prose prose-lg max-w-none">
+              <div className="bg-gradient-to-r from-gray-50 to-blue-50/50 rounded-2xl p-6 border border-gray-100">
+                <h3 className="text-lg font-semibold text-gray-800 mb-4 flex items-center space-x-2">
+                  <svg className="w-5 h-5 text-indigo-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                  </svg>
+                  <span>Nội dung thông báo</span>
+                </h3>
+                <div className="text-gray-700 leading-relaxed whitespace-pre-wrap text-base">
+                  {data.content || (
+                    <span className="text-gray-500 italic">Không có nội dung</span>
+                  )}
+                </div>
+              </div>
+            </div>
+
+            {/* Action Buttons */}
+            <div className="mt-8 flex items-center justify-between">
+              <div className="flex items-center space-x-2 text-sm text-gray-500">
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+                <span>Thông báo từ hệ thống</span>
+              </div>
+
+              <button
+                onClick={() => navigate(-1)}
+                className="group inline-flex items-center space-x-3 px-8 py-4 bg-gradient-to-r from-indigo-500 to-purple-600 text-white rounded-2xl shadow-lg hover:shadow-xl hover:from-indigo-600 hover:to-purple-700 transform hover:scale-105 transition-all duration-300"
+              >
+                <svg className="w-5 h-5 group-hover:transform group-hover:-translate-x-1 transition-transform duration-200" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+                </svg>
+                <span className="font-semibold">Quay lại danh sách</span>
+              </button>
+            </div>
+          </div>
+
+          {/* Bottom Decoration */}
+          <div className="h-1 bg-gradient-to-r from-indigo-500 via-purple-500 to-pink-500"></div>
+        </div>
+
+        {/* Additional Info Card */}
+        <div className="mt-6 bg-white/60 backdrop-blur-sm rounded-2xl p-4 border border-white/20">
+          <div className="flex items-center justify-center space-x-4 text-sm text-gray-600">
+            <div className="flex items-center space-x-2">
+              <div className="w-2 h-2 bg-green-400 rounded-full"></div>
+              <span>Đã xem thông báo</span>
+            </div>
+            <div className="w-1 h-1 bg-gray-300 rounded-full"></div>
+            <div className="flex items-center space-x-2">
+              <svg className="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+              <span>Thông báo hệ thống</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/stylistDashboard/Notifications.jsx
+++ b/frontend/src/components/stylistDashboard/Notifications.jsx
@@ -1,0 +1,229 @@
+import { notificationApi } from "../../api/services/notificationApi";
+import { useNavigate } from "react-router-dom";
+import React, { useState, useEffect } from "react";
+
+export default function Notifications() {
+  const [items, setItems] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    fetchNotifications();
+  }, []);
+
+  const fetchNotifications = async () => {
+    try {
+      const res = await notificationApi.getAllForStylist();
+      const notifications = res?.data ?? res;
+
+      const mapped = notifications.map((n) => ({
+        id: n.id,
+        title: n.title,
+        content: n.content,
+        read: n.isRead,
+        time: formatDate(n.createdAt),
+      }));
+
+      setItems(mapped);
+    } catch (error) {
+      console.error("Lỗi khi tải thông báo:", error);
+      alert("Không thể tải thông báo");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const markRead = async (id) => {
+    try {
+      await notificationApi.markAsRead(id);
+      setItems((prev) =>
+        prev.map((x) => (x.id === id ? { ...x, read: true } : x)),
+      );
+    } catch (err) {
+      console.error("Lỗi khi đánh dấu đã đọc:", err);
+      alert("Không thể đánh dấu đã đọc.");
+    }
+  };
+
+  const formatDate = (isoDate) => {
+    try {
+      const date = new Date(isoDate);
+      return date.toLocaleString();
+    } catch {
+      return isoDate;
+    }
+  };
+
+  const handleView = (id) => {
+    sessionStorage.setItem("selectedNotificationId", id);
+    navigate("/stylist-dashboard/notifications/detail");
+  };
+
+  const unreadCount = items.filter(n => !n.read).length;
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-indigo-50 p-6">
+      <div className="max-w-4xl mx-auto">
+        {/* Header Section */}
+        <div className="mb-8">
+          <div className="flex items-center space-x-4">
+            <div className="w-12 h-12 bg-gradient-to-br from-indigo-500 to-purple-600 rounded-xl flex items-center justify-center shadow-lg">
+              <svg className="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 17h5l-5 5v-5zM4 2h13a2 2 0 012 2v4l-7 7H4a2 2 0 01-2-2V4a2 2 0 012-2z" />
+              </svg>
+            </div>
+            <div>
+              <h1 className="text-3xl font-bold bg-gradient-to-r from-gray-800 to-gray-600 bg-clip-text text-transparent">
+                Thông báo
+              </h1>
+              <p className="text-gray-500 mt-1">
+                Quản lý các thông báo của bạn
+                {unreadCount > 0 && (
+                  <span className="ml-2 inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium bg-red-100 text-red-800">
+                    {unreadCount} chưa đọc
+                  </span>
+                )}
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {/* Stats Section */}
+        {items.length > 0 && (
+          <div className="mb-8 grid grid-cols-1 md:grid-cols-3 gap-4">
+            <div className="bg-white/60 backdrop-blur-sm rounded-2xl p-4 border border-white/20">
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="text-sm text-gray-600">Tổng số</p>
+                  <p className="text-2xl font-bold text-gray-900">{items.length}</p>
+                </div>
+                <div className="w-3 h-3 rounded-full bg-blue-400"></div>
+              </div>
+            </div>
+            
+            <div className="bg-white/60 backdrop-blur-sm rounded-2xl p-4 border border-white/20">
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="text-sm text-gray-600">Chưa đọc</p>
+                  <p className="text-2xl font-bold text-gray-900">{unreadCount}</p>
+                </div>
+                <div className="w-3 h-3 rounded-full bg-red-400"></div>
+              </div>
+            </div>
+            
+            <div className="bg-white/60 backdrop-blur-sm rounded-2xl p-4 border border-white/20">
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="text-sm text-gray-600">Đã đọc</p>
+                  <p className="text-2xl font-bold text-gray-900">{items.length - unreadCount}</p>
+                </div>
+                <div className="w-3 h-3 rounded-full bg-green-400"></div>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Main Content */}
+        <div className="bg-white/70 backdrop-blur-sm rounded-3xl shadow-xl border border-white/20 overflow-hidden">
+          {loading ? (
+            <div className="flex items-center justify-center py-16">
+              <div className="flex items-center space-x-3">
+                <div className="w-6 h-6 border-2 border-indigo-200 border-t-indigo-600 rounded-full animate-spin"></div>
+                <span className="text-gray-600 font-medium">Đang tải thông báo...</span>
+              </div>
+            </div>
+          ) : items.length === 0 ? (
+            <div className="flex flex-col items-center justify-center py-16">
+              <div className="w-20 h-20 bg-gray-100 rounded-full flex items-center justify-center mb-4">
+                <svg className="w-10 h-10 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 17h5l-5 5v-5zM4 2h13a2 2 0 012 2v4l-7 7H4a2 2 0 01-2-2V4a2 2 0 012-2z" />
+                </svg>
+              </div>
+              <h3 className="text-lg font-semibold text-gray-600 mb-2">Không có thông báo nào</h3>
+              <p className="text-gray-500">Bạn chưa có thông báo nào trong hệ thống</p>
+            </div>
+          ) : (
+            <div className="divide-y divide-gray-100">
+              {items.map((n, index) => (
+                <div
+                  key={n.id}
+                  className={`group relative p-6 hover:bg-gradient-to-r hover:from-indigo-50/50 hover:to-purple-50/30 transition-all duration-300 ${
+                    !n.read ? 'bg-gradient-to-r from-blue-50/50 to-indigo-50/30' : ''
+                  }`}
+                >
+                  {/* Unread indicator */}
+                  {!n.read && (
+                    <div className="absolute left-2 top-1/2 transform -translate-y-1/2 w-1 h-8 bg-gradient-to-b from-blue-500 to-indigo-600 rounded-full"></div>
+                  )}
+                  
+                  <div className="flex items-start justify-between space-x-4">
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center space-x-3 mb-2">
+                        <div className={`w-8 h-8 rounded-lg flex items-center justify-center ${
+                          !n.read 
+                            ? 'bg-gradient-to-br from-blue-500 to-indigo-600' 
+                            : 'bg-gray-100'
+                        }`}>
+                          <svg className={`w-4 h-4 ${!n.read ? 'text-white' : 'text-gray-500'}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 17h5l-5 5v-5zM4 2h13a2 2 0 012 2v4l-7 7H4a2 2 0 01-2-2V4a2 2 0 012-2z" />
+                          </svg>
+                        </div>
+                        <div className="flex-1">
+                          <h3 className={`font-semibold text-gray-900 group-hover:text-indigo-700 transition-colors duration-200 ${
+                            !n.read ? 'text-gray-900' : 'text-gray-700'
+                          }`}>
+                            {n.title}
+                          </h3>
+                          <div className="flex items-center space-x-2 mt-1">
+                            <svg className="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+                            </svg>
+                            <span className="text-sm text-gray-500">{n.time}</span>
+                          </div>
+                        </div>
+                      </div>
+                      
+                      {n.content && (
+                        <p className="text-gray-600 text-sm mt-2 line-clamp-2">
+                          {n.content}
+                        </p>
+                      )}
+                    </div>
+
+                    <div className="flex items-center space-x-2">
+                      <button
+                        className="group/btn flex items-center space-x-2 px-4 py-2 bg-gradient-to-r from-indigo-500 to-purple-500 text-white rounded-xl hover:from-indigo-600 hover:to-purple-600 transform hover:scale-105 transition-all duration-200 shadow-md hover:shadow-lg"
+                        onClick={() => handleView(n.id)}
+                      >
+                        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+                        </svg>
+                        <span className="font-medium">Xem</span>
+                      </button>
+                      
+                      {!n.read && (
+                        <button
+                          onClick={() => markRead(n.id)}
+                          className="group/mark flex items-center space-x-2 px-4 py-2 border-2 border-green-200 text-green-700 rounded-xl hover:bg-green-50 hover:border-green-300 transition-all duration-200"
+                        >
+                          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                          </svg>
+                          <span className="font-medium hidden sm:inline">Đánh dấu đã đọc</span>
+                        </button>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* Bottom Decoration */}
+          <div className="h-1 bg-gradient-to-r from-indigo-500 via-purple-500 to-pink-500"></div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/stylistDashboard/README.md
+++ b/frontend/src/components/stylistDashboard/README.md
@@ -1,1 +1,0 @@
-this is stylist dashboard component.

--- a/frontend/src/components/stylistDashboard/StylistDashboard.jsx
+++ b/frontend/src/components/stylistDashboard/StylistDashboard.jsx
@@ -1,0 +1,301 @@
+import React, { useEffect, useMemo, useState } from "react";
+import axiosClient from "../../api/axiosClient";
+
+export default function StylistDashboard() {
+  const [view, setView] = useState("month"); // or "week"
+  const [currentDate, setCurrentDate] = useState(new Date());
+  const [loading, setLoading] = useState(true);
+  const [rawSchedules, setRawSchedules] = useState([]);
+  const [error, setError] = useState("");
+
+  const getDayKey = (date) => new Date(date).toISOString().slice(0, 10);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        setLoading(true);
+        const res = await axiosClient.get("/time-schedule/me");
+        setRawSchedules(Array.isArray(res) ? res : []);
+      } catch (err) {
+        console.error(err);
+        setError("Không thể tải lịch làm việc.");
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchData();
+  }, []);
+
+  const normalizeSchedules = (schedules) => {
+    return schedules.flatMap((ws) => {
+      const date = getDayKey(ws.workingDate);
+
+      if (ws.isDayOff) {
+        return [
+          {
+            date,
+            title: "Nghỉ",
+            status: "OFF",
+          },
+        ];
+      }
+
+      return ws.timeSlots.map((slot) => {
+        const start = new Date(slot.startTime).toLocaleTimeString([], {
+          hour: "2-digit",
+          minute: "2-digit",
+        });
+        const end = new Date(slot.endTime).toLocaleTimeString([], {
+          hour: "2-digit",
+          minute: "2-digit",
+        });
+
+        return {
+          date,
+          title: `${start}-${end}`,
+          status: slot.isBooked ? "BOOKED" : "AVAILABLE",
+        };
+      });
+    });
+  };
+
+  const normalized = useMemo(() => normalizeSchedules(rawSchedules), [rawSchedules]);
+
+  const monthDays = useMemo(() => {
+    const start = new Date(currentDate.getFullYear(), currentDate.getMonth(), 1);
+    const startDay = start.getDay() || 7;
+    start.setDate(start.getDate() - (startDay - 1));
+
+    const days = [];
+    for (let i = 0; i < 42; i++) {
+      const d = new Date(start);
+      d.setDate(start.getDate() + i);
+      days.push(d);
+    }
+    return days;
+  }, [currentDate]);
+
+  const weekDays = useMemo(() => {
+    const start = new Date(currentDate);
+    const day = start.getDay() || 7;
+    start.setDate(start.getDate() - (day - 1));
+
+    const days = [];
+    for (let i = 0; i < 7; i++) {
+      const d = new Date(start);
+      d.setDate(start.getDate() + i);
+      days.push(d);
+    }
+    return days;
+  }, [currentDate]);
+
+  const getEventsByDate = (date) => {
+    return normalized.filter((e) => e.date === getDayKey(date));
+  };
+
+  const renderDayCell = (date) => {
+    const events = getEventsByDate(date);
+    const isToday = getDayKey(date) === getDayKey(new Date());
+    const isCurrentMonth = date.getMonth() === currentDate.getMonth();
+
+    return (
+      <div
+        key={date}
+        className={`min-h-[160px] border border-gray-200 p-3 overflow-hidden transition-all duration-200 hover:shadow-md ${
+          isCurrentMonth ? "bg-white" : "bg-gray-50/50"
+        } ${isToday ? "ring-2 ring-emerald-400 ring-offset-1" : ""}`}
+      >
+        <div className="flex justify-between items-center mb-2">
+          <span 
+            className={`text-sm font-medium ${
+              isCurrentMonth 
+                ? isToday 
+                  ? "text-emerald-600 font-semibold" 
+                  : "text-gray-900" 
+                : "text-gray-400"
+            }`}
+          >
+            {date.getDate()}
+          </span>
+          {isToday && (
+            <span className="text-xs px-2 py-1 bg-emerald-100 text-emerald-700 rounded-full font-medium shadow-sm">
+              Hôm nay
+            </span>
+          )}
+        </div>
+        <div className="space-y-1.5 text-xs">
+          {events.slice(0, 3).map((ev, i) => (
+            <div
+              key={i}
+              className={`truncate px-2 py-1.5 rounded-lg font-medium shadow-sm transition-all duration-150 ${
+                ev.status === "OFF"
+                  ? "bg-red-100 text-red-700 border-l-3 border-red-400"
+                  : ev.status === "BOOKED"
+                  ? "bg-blue-100 text-blue-700 border-l-3 border-blue-400"
+                  : "bg-emerald-100 text-emerald-700 border-l-3 border-emerald-400"
+              }`}
+            >
+              {ev.title}
+            </div>
+          ))}
+          {events.length > 3 && (
+            <div className="text-gray-500 text-[11px] font-medium mt-2 px-1">
+              +{events.length - 3} lịch khác...
+            </div>
+          )}
+        </div>
+      </div>
+    );
+  };
+
+  const goToday = () => setCurrentDate(new Date());
+  const prev = () => {
+    const newDate = new Date(currentDate);
+    if (view === "month") newDate.setMonth(currentDate.getMonth() - 1);
+    else newDate.setDate(currentDate.getDate() - 7);
+    setCurrentDate(newDate);
+  };
+  const next = () => {
+    const newDate = new Date(currentDate);
+    if (view === "month") newDate.setMonth(currentDate.getMonth() + 1);
+    else newDate.setDate(currentDate.getDate() + 7);
+    setCurrentDate(newDate);
+  };
+
+  const monthLabel = useMemo(
+    () =>
+      currentDate.toLocaleDateString("vi-VN", {
+        month: "long",
+        year: "numeric",
+      }),
+    [currentDate]
+  );
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-gray-50 to-gray-100 p-6">
+      <div className="max-w-7xl mx-auto">
+        {/* Header */}
+        <div className="mb-8">
+          <h1 className="text-3xl font-bold text-gray-800 mb-2">
+            📅 Tổng quan lịch làm việc
+          </h1>
+          <p className="text-gray-600">Quản lý và theo dõi lịch trình làm việc của bạn</p>
+        </div>
+
+        {/* Controls */}
+        <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6 mb-6">
+          <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
+            {/* View Toggle */}
+            <div className="flex bg-gray-100 rounded-lg p-1">
+              <button
+                onClick={() => setView("month")}
+                className={`px-4 py-2 rounded-md font-medium transition-all duration-200 ${
+                  view === "month" 
+                    ? "bg-emerald-600 text-white shadow-sm" 
+                    : "text-gray-600 hover:text-gray-800 hover:bg-gray-200"
+                }`}
+              >
+                Tháng
+              </button>
+              <button
+                onClick={() => setView("week")}
+                className={`px-4 py-2 rounded-md font-medium transition-all duration-200 ${
+                  view === "week" 
+                    ? "bg-emerald-600 text-white shadow-sm" 
+                    : "text-gray-600 hover:text-gray-800 hover:bg-gray-200"
+                }`}
+              >
+                Tuần
+              </button>
+            </div>
+
+            {/* Navigation */}
+            <div className="flex items-center gap-3">
+              <button 
+                onClick={goToday} 
+                className="px-4 py-2 bg-gray-100 hover:bg-gray-200 text-gray-700 rounded-lg font-medium transition-all duration-200 hover:shadow-sm"
+              >
+                Hôm nay
+              </button>
+              <button 
+                onClick={prev} 
+                className="px-3 py-2 bg-white border border-gray-300 hover:border-gray-400 rounded-lg transition-all duration-200 hover:shadow-sm"
+              >
+                Trước
+              </button>
+              <div className="min-w-[150px] text-center font-semibold text-gray-800 text-lg">
+                {monthLabel}
+              </div>
+              <button 
+                onClick={next} 
+                className="px-3 py-2 bg-white border border-gray-300 hover:border-gray-400 rounded-lg transition-all duration-200 hover:shadow-sm"
+              >
+                Sau
+              </button>
+            </div>
+          </div>
+        </div>
+
+        {/* Calendar */}
+        <div className="bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden">
+          {loading ? (
+            <div className="text-center py-12">
+              <div className="inline-flex items-center gap-3 text-gray-500">
+                <div className="animate-spin rounded-full h-6 w-6 border-2 border-emerald-600 border-t-transparent"></div>
+                <span className="text-lg">Đang tải lịch làm việc...</span>
+              </div>
+            </div>
+          ) : error ? (
+            <div className="text-center py-12">
+              <div className="text-red-600 bg-red-50 border border-red-200 rounded-lg p-4 inline-block">
+                {error}
+              </div>
+            </div>
+          ) : view === "month" ? (
+            <div className="grid grid-cols-7">
+              {["Thứ 2", "Thứ 3", "Thứ 4", "Thứ 5", "Thứ 6", "Thứ 7", "Chủ nhật"].map((d) => (
+                <div
+                  key={d}
+                  className="text-sm font-semibold border-b border-gray-200 p-4 bg-gradient-to-r from-gray-50 to-gray-100 text-gray-700 text-center"
+                >
+                  {d}
+                </div>
+              ))}
+              {monthDays.map((d) => renderDayCell(d))}
+            </div>
+          ) : (
+            <div className="grid grid-cols-7">
+              {weekDays.map((d, index) => (
+                <div key={d} className="border-r border-gray-200 last:border-r-0">
+                  <div className="text-sm font-semibold border-b border-gray-200 p-3 bg-gradient-to-r from-gray-50 to-gray-100 text-gray-700 text-center">
+                    {["Thứ 2", "Thứ 3", "Thứ 4", "Thứ 5", "Thứ 6", "Thứ 7", "Chủ nhật"][index]}
+                  </div>
+                  {renderDayCell(d)}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Legend */}
+        <div className="mt-6 bg-white rounded-xl shadow-sm border border-gray-200 p-4">
+          <h3 className="font-semibold text-gray-800 mb-3">Chú thích:</h3>
+          <div className="flex flex-wrap gap-4 text-sm">
+            <div className="flex items-center gap-2">
+              <div className="w-4 h-4 bg-emerald-100 border-l-3 border-emerald-400 rounded"></div>
+              <span className="text-gray-700">Có thể đặt lịch</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <div className="w-4 h-4 bg-blue-100 border-l-3 border-blue-400 rounded"></div>
+              <span className="text-gray-700">Đã có lịch hẹn</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <div className="w-4 h-4 bg-red-100 border-l-3 border-red-400 rounded"></div>
+              <span className="text-gray-700">Ngày nghỉ</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/stylistDashboard/StylistHeader.jsx
+++ b/frontend/src/components/stylistDashboard/StylistHeader.jsx
@@ -1,0 +1,197 @@
+import React, { useState, useRef, useEffect } from "react";
+import { useAuth } from "../../hooks/useAuth";
+import { useAuthContext } from "../../contexts/AuthContext";
+import { useNavigate } from "react-router-dom";
+
+const StylistHeader = () => {
+  const { logout } = useAuth();
+  const { user, clearAuthState } = useAuthContext();
+  const [showDropdown, setShowDropdown] = useState(false);
+  const dropdownRef = useRef(null);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const handleClickOutside = (event) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target)) {
+        setShowDropdown(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  const handleLogout = () => {
+    logout();
+    clearAuthState();
+    window.location.href = "/login";
+  };
+
+  const getCurrentTime = () => {
+    return new Date().toLocaleString("en-US", {
+      weekday: "long",
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  };
+
+  return (
+    <header className="bg-white shadow-lg border-b border-gray-200 sticky top-0 z-30 w-full">
+      <div className="w-full px-6 py-4">
+        <div className="flex items-center justify-between w-full">
+          <div className="flex-1"></div>
+
+          <div className="flex items-center justify-center flex-1">
+            <div className="text-center bg-gray-50 px-4 py-2 rounded-lg border border-gray-200">
+              <div className="text-xs text-gray-500 font-medium">Current Time</div>
+              <div className="text-sm font-semibold text-gray-700">{getCurrentTime()}</div>
+            </div>
+          </div>
+
+          <div className="flex items-center justify-end space-x-4 flex-1">
+            <button
+                  onClick={() => (window.location.href = "/stylist-dashboard/notifications")}
+                  className="relative bg-white p-2 text-gray-400 hover:text-gray-600 hover:bg-gray-50 rounded-lg transition-all duration-200 border border-transparent"
+                >
+              <svg
+                className="w-6 h-6"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M15 17h5l-3-3V9a6 6 0 10-12 0v5l-3 3h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"
+                />
+              </svg>
+              <span className="absolute -top-1 -right-1 block h-3 w-3 bg-red-500 rounded-full border-2 border-white"></span>
+            </button>
+
+            <div className="relative" ref={dropdownRef}>
+              <button
+                onClick={() => setShowDropdown(!showDropdown)}
+                className="flex bg-white items-center space-x-3 p-2 rounded-lg hover:bg-gray-50 transition-colors text-gray-600 border border-gray-200 hover:border-gray-300"
+              >
+                <div className="flex items-center space-x-3">
+                  <div className="relative">
+                    {user?.avatar ? (
+                      <img
+                        src={user.avatar}
+                        alt={user.fullName}
+                        className="w-8 h-8 rounded-full object-cover border-2 border-gray-200 shadow-sm"
+                      />
+                    ) : (
+                      <div className="w-8 h-8 bg-gray-50 rounded-full flex items-center justify-center border-2 border-gray-200 shadow-sm">
+                        <svg
+                          className="w-4 h-4 text-gray-400"
+                          fill="none"
+                          stroke="currentColor"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth={2}
+                            d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
+                          />
+                        </svg>
+                      </div>
+                    )}
+                    <div className="absolute -bottom-0.5 -right-0.5 w-3 h-3 bg-green-500 border-2 border-white rounded-full"></div>
+                  </div>
+                  <div className="hidden md:block text-left">
+                    <div className="text-sm font-medium text-gray-700">
+                      {user?.fullName || "Stylist"}
+                    </div>
+                    <div className="text-xs text-gray-500">
+                      {user?.role || "STYLIST"}
+                    </div>
+                  </div>
+
+                  <svg
+                    className={`w-4 h-4 text-gray-400 transition-transform duration-200 ${
+                      showDropdown ? "rotate-180" : ""
+                    }`}
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M19 9l-7 7-7-7"
+                    />
+                  </svg>
+                </div>
+              </button>
+
+              {showDropdown && (
+                <div className="absolute right-0 mt-2 w-56 bg-white rounded-lg shadow-lg border border-gray-200 py-2 z-50">
+                  <div className="px-4 py-3 border-b border-gray-100">
+                    <div className="flex items-center space-x-3">
+                      <div className="w-10 h-10 bg-gray-100 rounded-full flex items-center justify-center border border-gray-200">
+                        <svg
+                          className="w-5 h-5 text-gray-500"
+                          fill="none"
+                          stroke="currentColor"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth={2}
+                            d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
+                          />
+                        </svg>
+                      </div>
+                      <div>
+                        <div className="font-medium text-gray-800">
+                          {user?.fullName || "Stylist"}
+                        </div>
+                        <div className="text-sm text-gray-500">
+                          {user?.email || "stylist@example.com"}
+                        </div>
+                        <div className="text-xs text-gray-500 font-medium">
+                          {user?.role || "STYLIST"}
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="border-t border-gray-100 pt-2">
+                    <button
+                      onClick={handleLogout}
+                      className="w-full text-left px-4 py-2 text-sm text-red-600 hover:bg-red-50 hover:text-red-700 flex items-center space-x-3 transition-colors"
+                    >
+                      <svg
+                        className="w-4 h-4 text-red-500"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1"
+                        />
+                      </svg>
+                      <span>Sign Out</span>
+                    </button>
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </header>
+  );
+};
+
+export default StylistHeader;

--- a/frontend/src/components/stylistDashboard/StylistLayout.jsx
+++ b/frontend/src/components/stylistDashboard/StylistLayout.jsx
@@ -1,0 +1,42 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Navigate, useLocation } from "react-router-dom";
+import StylistHeader from "./StylistHeader";
+import StylistSidebar from "./StylistSidebar";
+
+/** TODO: Replace with real AuthContext/Redux */
+function useFakeAuth() {
+  return { isAuthed: true, role: "STYLIST" };
+}
+
+const StylistLayout = ({ title, subtitle, children }) => {
+  const { isAuthed, role } = useFakeAuth();
+  const location = useLocation();
+
+  if (!isAuthed) return <Navigate to="/login" state={{ from: location }} replace />;
+  if (role !== "STYLIST") return <Navigate to="/" replace />;
+
+  return (
+    <div className="min-h-screen bg-gray-50 flex w-full">
+      <StylistSidebar />
+      <div className="flex-1 flex flex-col min-w-0 w-full">
+        <StylistHeader title={title} subtitle={subtitle} />
+        <main className="flex-1 overflow-y-auto">
+          <div className="w-full p-6">
+            <div className="max-w-7xl mx-auto w-full">
+              {children}
+            </div>
+          </div>
+        </main>
+      </div>
+    </div>
+  );
+};
+
+StylistLayout.propTypes = {
+  title: PropTypes.string,
+  subtitle: PropTypes.string,
+  children: PropTypes.node,
+};
+
+export default StylistLayout;

--- a/frontend/src/components/stylistDashboard/StylistSidebar.jsx
+++ b/frontend/src/components/stylistDashboard/StylistSidebar.jsx
@@ -1,0 +1,152 @@
+import React, { useState } from "react";
+import { Link, useLocation } from "react-router-dom";
+import logo from "../../assets/logo-icon.png";
+
+const StylistSidebar = () => {
+  const [isCollapsed, setIsCollapsed] = useState(false);
+  const location = useLocation();
+
+  const menuItems = [
+    {
+      key: "dashboard",
+      label: "Lịch làm việc",
+      path: "/stylist-dashboard",
+      icon: (
+        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7v10M16 7v10M4 11h16" />
+        </svg>
+      ),
+    },
+    {
+      key: "notifications",
+      label: "Thông báo",
+      path: "/stylist-dashboard/notifications",
+      icon: (
+        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
+        </svg>
+      ),
+    },
+    {
+      key: "leaves",
+      label: "Xem đơn nghỉ",
+      path: "/stylist-dashboard/leaves",
+      icon: (
+        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+        </svg>
+      ),
+    },
+    {
+      key: "create-leave",
+      label: "Tạo đơn nghỉ",
+      path: "/stylist-dashboard/leaves/create",
+      icon: (
+        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+        </svg>
+      ),
+    },
+  ];
+
+  const isActive = (path) => location.pathname === path || location.pathname.startsWith(path);
+
+  return (
+    <>
+      {!isCollapsed && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 z-40 lg:hidden" onClick={() => setIsCollapsed(true)} />
+      )}
+
+      <aside
+        className={`
+          fixed top-0 left-0 bottom-0 overflow-y-auto bg-gradient-to-b from-purple-800 via-pink-700 to-red-600 text-white z-50
+          transform transition-all duration-300 ease-in-out
+          ${isCollapsed ? "-translate-x-full lg:translate-x-0 lg:w-16" : "translate-x-0 w-64"}
+          lg:relative lg:transform-none lg:flex-shrink-0
+        `}
+      >
+        <div className="flex items-center justify-between p-4 border-b border-white/20 h-16">
+          <div className="flex items-center space-x-3">
+            <img src={logo} alt="Logo" className="h-8 w-8" />
+            {!isCollapsed && (
+              <div>
+                <h1 className="text-lg font-bold">Stylist</h1>
+                <p className="text-xs text-pink-200">Hair Booking</p>
+              </div>
+            )}
+          </div>
+
+          <button
+            onClick={() => setIsCollapsed(!isCollapsed)}
+            className="hidden lg:block p-1 rounded-lg hover:bg-white/10 transition-colors"
+          >
+            <svg
+              className={`w-5 h-5 transition-transform duration-300 ${isCollapsed ? "rotate-180" : ""}`}
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 19l-7-7 7-7m8 14l-7-7 7-7" />
+            </svg>
+          </button>
+        </div>
+
+        <nav className="flex-1 px-2 py-4 overflow-y-auto">
+          <ul className="space-y-1">
+            {menuItems.map((item) => (
+              <li key={item.key}>
+                <Link
+                  to={item.path}
+                  className={`
+                    group flex items-center px-3 py-3 text-sm font-medium rounded-lg
+                    transition-all duration-200 relative
+                    ${isActive(item.path)
+                      ? "bg-white/20 text-white shadow-lg border-r-4 border-pink-300"
+                      : "text-pink-100 hover:bg-white/10 hover:text-white"}
+                  `}
+                  title={isCollapsed ? item.label : ""}
+                >
+                  <div className="flex items-center min-w-0 flex-1">
+                    <div className="flex-shrink-0">{item.icon}</div>
+                    {!isCollapsed && <span className="ml-3 truncate">{item.label}</span>}
+                  </div>
+
+                  {isCollapsed && (
+                    <div className="absolute left-full ml-2 px-2 py-1 bg-gray-900 text-white text-xs rounded-md opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none whitespace-nowrap z-50">
+                      {item.label}
+                    </div>
+                  )}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </nav>
+
+        <div className="p-2 space-y-2 border-t border-white/20">
+          <Link
+            to="/"
+            className="w-full flex items-center justify-center px-3 py-2 text-sm font-medium text-pink-200 hover:text-white hover:bg-white/10 rounded-lg transition-colors"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
+            </svg>
+            {!isCollapsed && <span className="ml-2">Trang chính</span>}
+          </Link>
+        </div>
+      </aside>
+
+      {isCollapsed && (
+        <button
+          onClick={() => setIsCollapsed(false)}
+          className="fixed top-4 left-4 z-40 lg:hidden bg-gray-900 text-white p-2 rounded-lg shadow-lg"
+        >
+          <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+        </button>
+      )}
+    </>
+  );
+};
+
+export default StylistSidebar;

--- a/frontend/src/pages/stylist/StylistCreateLeavePage.jsx
+++ b/frontend/src/pages/stylist/StylistCreateLeavePage.jsx
@@ -1,0 +1,16 @@
+import React from "react";
+import StylistLayout from "../../components/stylistDashboard/StylistLayout";
+import CreateLeaves from "../../components/stylistDashboard/CreateLeaves";
+
+const StylistCreateLeavePage = () => {
+  return (
+    <StylistLayout
+      title="Tạo yêu cầu nghỉ phép"
+      subtitle="Gửi yêu cầu nghỉ cho quản lý phê duyệt"
+    >
+      <CreateLeaves />
+    </StylistLayout>
+  );
+};
+
+export default StylistCreateLeavePage;

--- a/frontend/src/pages/stylist/StylistDashboardPage.jsx
+++ b/frontend/src/pages/stylist/StylistDashboardPage.jsx
@@ -1,0 +1,15 @@
+import React from "react";
+import StylistLayout from "../../components/stylistDashboard/StylistLayout";
+import StylistDashboard from "../../components/stylistDashboard/StylistDashboard";
+
+const StylistDashboardPage = () => {
+  return (
+    <StylistLayout>
+        <div className="flex-1 p-6">
+          <StylistDashboard />
+        </div>
+    </StylistLayout>
+  );
+};
+
+export default StylistDashboardPage;

--- a/frontend/src/pages/stylist/StylistLeaveManagementPage.jsx
+++ b/frontend/src/pages/stylist/StylistLeaveManagementPage.jsx
@@ -1,0 +1,18 @@
+import React from "react";
+import StylistLayout from "../../components/stylistDashboard/StylistLayout";
+import StylistSideBar from "../../components/stylistDashboard/StylistSidebar";
+import Leaves from "../../components/stylistDashboard/Leaves";
+
+const StylistLeaveManagementPage = () => {
+  return (
+    <StylistLayout
+      title="Leave Management"
+      subtitle="Xem lịch sử nghỉ phép và thao tác hủy yêu cầu khi cần"
+      sidebar={<StylistSideBar />}
+    >
+      <Leaves />
+    </StylistLayout>
+  );
+};
+
+export default StylistLeaveManagementPage;

--- a/frontend/src/pages/stylist/StylistNotificationsPage.jsx
+++ b/frontend/src/pages/stylist/StylistNotificationsPage.jsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { useLocation } from "react-router-dom";
+import StylistLayout from "../../components/stylistDashboard/StylistLayout";
+import StylistSideBar from "../../components/stylistDashboard/StylistSidebar";
+import Notifications from "../../components/stylistDashboard/Notifications";
+import NotificationDetail from "../../components/stylistDashboard/NotificationDetail";
+
+const StylistNotificationsPage = () => {
+  const location = useLocation();
+  const isDetail = location.pathname.endsWith("/detail");
+
+  return (
+    <StylistLayout
+      title="Notifications"
+      subtitle="Xem và đánh dấu đọc các thông báo của bạn"
+      sidebar={<StylistSideBar />}
+    >
+      {isDetail ? <NotificationDetail /> : <Notifications />}
+    </StylistLayout>
+  );
+};
+
+export default StylistNotificationsPage;


### PR DESCRIPTION
Link redmine: https://edu-redmine.sun-asterisk.vn/issues/91442

# 📋 Summary  
- Added **Stylist**-only workspace with dedicated layout and sidebar  
- Implemented **Work Schedule Overview** (weekly/monthly) powered by `/time-schedule/me`  
- Built **Leave Management**: view history, create request, cancel pending requests  
- Integrated **Notifications**: list, detail, mark-as-read  

---

# ✨ Features Added  

## 📅 Work Schedule Overview  
- Month/Week toggle with responsive grid  
- Highlights:  
  - Day off vs working day  
- Error/loading states and empty data fallback  

## 📝 Leave Form
- **View leaves** with status chips (PENDING / APPROVED / REJECTED / CANCELLED)  
- **Create leave request** (date + optional reason)  
- **Cancel leave** if status is `PENDING` (soft UI update on success)  
- Inline confirmations + toast/console banner feedback  

## 🔔 Notifications  
- **List notifications** (sorted by created time)  
- **View details** in a side panel/modal  
- **Mark as read** (optimistic UI) with unread badges  

## 🧭 Stylist Navigation & Separation  
- **StylistSidebar** (no longer using Admin sidebar)  
- **StylistLayout** shell (header + sidebar + content)  
- **Routes** grouped under `/stylist-*` paths  

## 🛡️ Security / Access Control  
- **StylistProtectedRoute** to gate stylist pages  
- Reads auth role from context/localStorage; redirects unauthorized users  
- Token-aware axios client (auto removes invalid token on 401)  

---

# 🔧 Technical Changes  

## Frontend Updates  
- `src/pages/stylist/StylistDashboardPage.jsx` — Work schedule overview entry page  
- `src/pages/stylist/Leaves.jsx` — Leave list + cancel action  
- `src/pages/stylist/CreateLeave.jsx` — Create leave request form  
- `src/pages/stylist/Notifications.jsx` — Notification list + detail + mark-as-read  
- `src/components/stylistDashboard/StylistSidebar.jsx` — New stylist-only sidebar  
- `src/components/stylistDashboard/StylistLayout.jsx` — Shell layout for stylist area  
- `src/components/common/StylistProtectedRoute.jsx` — Route guard for stylist role  
- `src/api/axiosClient.js` — Token handling & 401 cleanup (already present, used here)  
- `src/api/services/stylistApi.js` — (Optional) placeholder service module for stylist endpoints  
- `src/App.jsx` — Updated routing to mount stylist pages under:  
  - `/stylist-dashboard`  
  - `/stylist/leaves`  
  - `/stylist/leaves/new`  
  - `/stylist/notifications`  

## Key Functions Added  
- `fetchWorkSchedule()` — GET `/time-schedule/me`, normalizes array to UI map  
- `fetchLeaves()` — GET `/leaves`, populates history  
- `createLeave(payload)` — POST `/leaves`  
- `cancelLeave(id)` — DELETE `/leaves/:id` (only when status = PENDING)  
- `fetchNotifications()` — GET `/notifications`  
- `markNotificationRead(id)` — PATCH `/notifications/:id/read`  
- `isStylist()` — detects role from auth context/localStorage for guard rendering  

---

# 🔄 Backend Compatibility  

## API Endpoints Used  
- **Work Schedule**  
  - `GET /time-schedule/me` — 7-day schedule (today + next 6 days)  
- **Leaves**  
  - `GET /leaves` — List leaves of current stylist  
  - `POST /leaves` — Create leave `{ date, reason? }`  
  - `DELETE /leaves/:id` — Cancel leave (PENDING only)  
- **Notifications**  
  - `GET /notifications` — Stylist notifications  
  - `PATCH /notifications/:id/read` — Mark notification as read  

> Axios base URL from `VITE_API_PATH` (falls back to `http://localhost:3000/api`).  

---

# 🧪 How to Test  

1. **Auth & Access**  
   - Login as a stylist user (role = `STYLIST`)  
   - Navigate to `/stylist-dashboard` — should render without admin UI  
   - Attempt to access stylist pages as non-stylist — expect redirect/guard  

2. **Work Schedule**  
   - Ensure `/time-schedule/me` returns data (7-day window)  
   - Toggle Month/Week views  
   - Verify day-off indicators and slot rendering  

3. **Leaves**  
   - Go to `/stylist/leaves` — items should show status chips  
   - Click **New Leave** → submit with a valid date → success banner + list refresh  
   - Try **Cancel** on a `PENDING` item → status becomes `CANCELLED`  

4. **Notifications**  
   - Open `/stylist/notifications` — unread items highlighted  
   - Open a notification detail → mark as read → badge count decreases  

5. **Error States**  
   - Temporarily break network → see error messages & non-crashing fallbacks  
   - Expired token → verify auto-cleanup and login redirect behavior  

